### PR TITLE
Move Submit Button from header to footer

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -151,13 +151,6 @@ export default async function Home({ searchParams }: { searchParams: Promise<{ q
               >
                 📚 Blog
               </Link>
-              <SubmitButton />
-              <a
-                href="/submit"
-                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition"
-              >
-                Submit Pricing
-              </a>
             </div>
           </div>
         </div>
@@ -330,12 +323,12 @@ export default async function Home({ searchParams }: { searchParams: Promise<{ q
             <Link href="/blog" className="hover:text-purple-600 dark:hover:text-purple-400 transition">
               📚 Blog
             </Link>
-            <a href="/submit" className="hover:text-purple-600 dark:hover:text-purple-400 transition">
-              📝 Submit Pricing
-            </a>
-            <a href="https://github.com/SumitLubal/llm-cost-compass" className="hover:text-purple-600 dark:hover:text-purple-400 transition" target="_blank" rel="noopener">
-              ⭐ GitHub
-            </a>
+            <div className="flex gap-2">
+              <a href="https://github.com/SumitLubal/llm-cost-compass" className="hover:text-purple-600 dark:hover:text-purple-400 transition" target="_blank" rel="noopener">
+                ⭐ GitHub
+              </a>
+              <SubmitButton />
+            </div>
           </div>
           <p>Prices updated daily • Always show better alternatives • Never hide providers</p>
           <p className="mt-2 text-xs text-gray-500 dark:text-gray-500">


### PR DESCRIPTION
This PR moves the Submit button from the header to the footer to provide a cleaner layout.

## Changes Made:
- Remove duplicate Submit buttons from the page header
- Add single Submit Button component to the footer next to the GitHub link
- Cleaner header layout with fewer action buttons

## Rationale:
The page header had two separate submit buttons (SubmitButton component and Submit Pricing link), creating redundancy and visual clutter. This change consolidates the submission functionality into a single, prominent button in the footer area.

The Submit Button component provides a more visually appealing design with gradient background compared to the simple text link that was previously in the footer.

## Technical Details:
- Modified: src/app/page.tsx
- Removed: Duplicate Submit buttons from header
- Added: SubmitButton component to footer section
- Branch: feature/move-submit-button

## Testing:
- Verified header layout is clean with no duplicate buttons
- Verified footer contains both GitHub link and Submit button as requested
- Responsive layout maintained
- All existing functionality preserved